### PR TITLE
Fixed an issue where random results were displayed on Gravity Forms page.

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -1351,6 +1351,12 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 
 				$prompt = GFCommon::replace_variables( $prompt, $form, $entry, false, false, false, 'text' );
 
+				// If prompt is empty, do not generate any completion response, skip with blank.
+				if( empty( $prompt ) ) {
+					$response = '';
+					break;
+				}
+
 				$response = $this->make_request( 'completions', array(
 					'model'  => $model,
 					'prompt' => $prompt,
@@ -1368,6 +1374,12 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 
 				$input       = GFCommon::replace_variables( $input, $form, $entry, false, false, false, 'text' );
 				$instruction = GFCommon::replace_variables( $instruction, $form, $entry, false, false, false, 'text' );
+
+				// If input or instruction is empty, do not generate any edit response, skip with blank.
+				if( empty( $input ) || empty( $instruction ) ) {
+					$response = '';
+					break;
+				}
 
 				$response = $this->make_request( 'edits', array(
 					'model'       => $model,

--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -1352,7 +1352,7 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 				$prompt = GFCommon::replace_variables( $prompt, $form, $entry, false, false, false, 'text' );
 
 				// If prompt is empty, do not generate any completion response, skip with blank.
-				if( empty( $prompt ) ) {
+				if ( empty( $prompt ) ) {
 					$response = '';
 					break;
 				}
@@ -1376,7 +1376,7 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 				$instruction = GFCommon::replace_variables( $instruction, $form, $entry, false, false, false, 'text' );
 
 				// If input or instruction is empty, do not generate any edit response, skip with blank.
-				if( empty( $input ) || empty( $instruction ) ) {
+				if ( empty( $input ) || empty( $instruction ) ) {
 					$response = '';
 					break;
 				}

--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -1353,8 +1353,7 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 
 				// If prompt is empty, do not generate any completion response, skip with blank.
 				if ( empty( $prompt ) ) {
-					$response = '';
-					break;
+					return '';
 				}
 
 				$response = $this->make_request( 'completions', array(
@@ -1377,8 +1376,7 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 
 				// If input or instruction is empty, do not generate any edit response, skip with blank.
 				if ( empty( $input ) || empty( $instruction ) ) {
-					$response = '';
-					break;
+					return '';
 				}
 
 				$response = $this->make_request( 'edits', array(


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2124678874/42804?folderId=3808239

## Summary

Open AI generates random results on the Gravity Forms edit page after the fields-open ai feed merge tag is saved. The random results are generated because of the empty input / prompt values. We can skip response generation for empty string values.

_**BEFORE**_
<img width="646" alt="Screenshot 2023-01-24 at 3 31 35 PM" src="https://user-images.githubusercontent.com/26293394/214263893-fb1021d4-606c-41ae-a540-59bb1e214f1f.png">

_**AFTER**_
<img width="652" alt="Screenshot 2023-01-24 at 3 31 52 PM" src="https://user-images.githubusercontent.com/26293394/214263921-4712dc4e-f2c1-4e5f-9894-8125bf9854ec.png">



## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.