### PR TITLE
Fixed an issue where GPPA values would not get populated when Gravity Forms Open AI was enabled.

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -1279,6 +1279,11 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 	 * @return string The text with merge tags processed.
 	 */
 	public function replace_merge_tags( $text, $form, $entry, $url_encode, $esc_html, $nl2br, $format ) {
+		// Process merge tags only if they are an openai feed.
+		if ( ! strpos( $text, 'openai_feed' ) ) {
+			return $text;
+		}
+
 		preg_match_all( '/{[^{]*?:(\d+(\.\d+)?)(:(.*?))?}/mi', $text, $field_variable_matches, PREG_SET_ORDER );
 
 		foreach ( $field_variable_matches as $match ) {


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2125878606/42845?folderId=3808239

## Summary

Open AI call on `gform_pre_replace_merge_tags` filter was pre replacing merge tags for GP Populate Anything, thus not completely generating GPPA results in some scenarios. This adds a check that the merge tags are only processed if they are openai_feed merge tags for the case of GFOAI.


## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.