### PR TITLE
Added caps for Members Plugin.

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -57,6 +57,41 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 	protected $_short_title = 'OpenAI';
 
 	/**
+	 * Defines the capabilities needed for the Add-On. Ensures compatibility
+	 * with Members plugin.
+	 *
+	 * @var array $_capabilities The capabilities needed for the Add-On
+	 */
+	protected $_capabilities = array(
+		'gravityforms-openai',
+		'gravityforms-openai_uninstall',
+		'gravityforms-openai_results',
+		'gravityforms-openai_settings',
+		'gravityforms-openai_form_settings',
+	);
+
+	/**
+	 * Defines the capability needed to access the Add-On settings page.
+	 *
+	 * @var string $_capabilities_settings_page The capability needed to access the Add-On settings page.
+	 */
+	protected $_capabilities_settings_page = 'gravityforms-openai_settings';
+
+	/**
+	 * Defines the capability needed to access the Add-On form settings page.
+	 *
+	 * @var string $_capabilities_form_settings The capability needed to access the Add-On form settings page.
+	 */
+	protected $_capabilities_form_settings = 'gravityforms-openai_form_settings';
+
+	/**
+	 * Defines the capability needed to uninstall the Add-On.
+	 *
+	 * @var string $_capabilities_uninstall The capability needed to uninstall the Add-On.
+	 */
+	protected $_capabilities_uninstall = 'gravityforms-openai_uninstall';
+
+	/**
 	 * Disable async feed processing for now as it can prevent results mapped to fields from working in notifications.
 	 *
 	 * @var bool

--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -57,8 +57,7 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 	protected $_short_title = 'OpenAI';
 
 	/**
-	 * Defines the capabilities needed for the Add-On. Ensures compatibility
-	 * with Members plugin.
+	 * Defines the capabilities needed for the Add-On.
 	 *
 	 * @var array $_capabilities The capabilities needed for the Add-On
 	 */


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2157845917/44347?folderId=3808239

## Summary

[Members plugin](https://wordpress.org/plugins/members/) hides the GF Open AI Setting. This adds the required caps for it.

> **_Members plugin "Edit Capabilities" page before the update:_**

<img width="770" alt="Screenshot 2023-02-17 at 4 29 13 PM" src="https://user-images.githubusercontent.com/26293394/219631762-86c2b251-f596-4f49-87af-600dd8b1dfba.png">

> **_Members plugin "Edit Capabilities" page after this update:_**

<img width="765" alt="Screenshot 2023-02-17 at 4 28 52 PM" src="https://user-images.githubusercontent.com/26293394/219631868-a29e5ef7-873e-4224-b10c-8644a3600b61.png">



> **_Non-Admin's form settings before the update:_**

<img width="902" alt="Screenshot 2023-02-17 at 4 27 53 PM" src="https://user-images.githubusercontent.com/26293394/219632273-9a0871d3-4829-44ef-885c-a2af03c4b860.png">


> **_Non-Admin's form settings after the update (and having granted the caps):_**

<img width="916" alt="Screenshot 2023-02-17 at 4 28 28 PM" src="https://user-images.githubusercontent.com/26293394/219632296-72534156-fe0a-48c7-bbe4-5bd768362364.png">


## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.