### PR TITLE
Added a Gravity Flow Step Type for OpenAI.

### DIFF
--- a/gravityforms-openai.php
+++ b/gravityforms-openai.php
@@ -29,7 +29,16 @@ add_action( 'gform_loaded', function() {
 	require plugin_dir_path( __FILE__ ) . 'class-gwiz-gf-openai.php';
 
 	GFAddOn::register( 'GWiz_GF_OpenAI' );
-}, 5 );
+}, 0 ); // Load before Gravity Flow
+
+/*
+ * Gravity Flow compatibility.
+ */
+add_action( 'gravityflow_loaded', function() {
+	require_once( gwiz_gf_openai()->get_base_path() . '/includes/class-gravity-flow-step-feed-gwiz-gf-openai.php' );
+
+	Gravity_Flow_Steps::register( new Gravity_Flow_Step_Feed_GWiz_GF_OpenAI() );
+} );
 
 /**
  * Returns an instance of the GWiz_GF_OpenAI class

--- a/includes/class-gravity-flow-step-feed-gwiz-gf-openai.php
+++ b/includes/class-gravity-flow-step-feed-gwiz-gf-openai.php
@@ -1,0 +1,47 @@
+<?php
+defined( 'ABSPATH' ) || die();
+
+class Gravity_Flow_Step_Feed_GWiz_GF_OpenAI extends Gravity_Flow_Step_Feed_Add_On {
+	/**
+	 * The step type.
+	 *
+	 * @var string
+	 */
+	public $_step_type = 'gwiz_gf_openai';
+
+	/**
+	 * The name of the class used by the add-on.
+	 *
+	 * @var string
+	 */
+	protected $_class_name = 'GWiz_GF_OpenAI';
+
+	/**
+	 * Returns the step label.
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		return 'OpenAI';
+	}
+
+	/**
+	 * Returns the step icon.
+	 */
+	public function get_icon_url() {
+		return gwiz_gf_openai()->get_base_url() . '/icon.svg';
+	}
+
+	/**
+	 * Returns the feed name.
+	 *
+	 * @param array $feed The Emma feed properties.
+	 *
+	 * @return string
+	 */
+	public function get_feed_label( $feed ) {
+		$label = $feed['meta']['feed_name'];
+
+		return $label;
+	}
+}


### PR DESCRIPTION
Credit: @idealien

## Summary

* Add a new Gravity Flow Step Type for the OpenAI feed. When used, it will prevent the feed from firing during submission and delay it until the step is run.

### Screenshot

![CleanShot 2023-03-02 at 16 39 10](https://user-images.githubusercontent.com/375381/222576103-f4f50eb1-4491-489c-a013-9475c2205985.png)
