### PR TITLE
Fixed issues with Open AI feed not duplicating when form was duplicated.

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -1460,7 +1460,6 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 
 		preg_match_all( '/{[^{]*?:(\d+(\.\d+)?)(:(.*?))?}/mi', $text, $field_variable_matches, PREG_SET_ORDER );
 
-		$modifiers = array();
 		foreach ( $field_variable_matches as $match ) {
 			$input_id      = $match[1];
 			$i             = $match[0][0] === '{' ? 4 : 5;
@@ -1501,7 +1500,7 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 				continue;
 			}
 
-			$replacement = $this->get_merge_tag_replacement( $form, $entry, $feed_id, $url_encode, $esc_html, $nl2br, $format, $modifiers );
+			$replacement = $this->get_merge_tag_replacement( $form, $entry, $feed_id, $url_encode, $esc_html, $nl2br, $format, array() );
 			$text        = str_replace( $match[0], $replacement, $text );
 		}
 

--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -477,6 +477,10 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 		return $choices;
 	}
 
+	public function can_duplicate_feed( $feed_id ) {
+		return true;
+	}
+
 	public function feed_settings_fields() {
 		return array(
 			array(
@@ -1456,6 +1460,7 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 
 		preg_match_all( '/{[^{]*?:(\d+(\.\d+)?)(:(.*?))?}/mi', $text, $field_variable_matches, PREG_SET_ORDER );
 
+		$modifiers = array();
 		foreach ( $field_variable_matches as $match ) {
 			$input_id      = $match[1];
 			$i             = $match[0][0] === '{' ? 4 : 5;
@@ -1507,7 +1512,7 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 		$feed     = $this->get_feed( $feed_id );
 		$endpoint = rgars( $feed, 'meta/endpoint' );
 
-		if ( ! $endpoint ) {
+		if ( ! $endpoint || rgar( $feed, 'form_id' ) !== rgar( $form, 'id' ) ) {
 			return '';
 		}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2208195026/46565?folderId=3808239

## Summary

**1.** [This](https://github.com/gravitywiz/gravityforms-openai/compare/saif/fix/46565-feed-form-duplication#diff-ba1162f52c9cca67b2864d9b8baaab56c721ca7cfbad7fd81b335223864bf864R1515) adds a check to ensure an Open AI feed merge tag is only executed if it is included on the same form. The conditional added here check the feed form ID with the current form ID. A quick screencast of this update: https://www.loom.com/share/f5c7ba0c8d264e519dd727e7f0a2c664


**2.** [This](https://github.com/gravitywiz/gravityforms-openai/compare/saif/fix/46565-feed-form-duplication#diff-ba1162f52c9cca67b2864d9b8baaab56c721ca7cfbad7fd81b335223864bf864R1463) came about in testing. There were PHP warnings for `Notice: Undefined variable: modifiers`. There are two separate foreach loops following this code update. `modifiers` is set on the first one, and used on the second one. In an edge case scenario when the first foreach does not run, `modifiers` would not be set, and if the second one does run the warning is triggered.

<img width="927" alt="Screenshot 2023-04-17 at 4 05 00 PM" src="https://user-images.githubusercontent.com/26293394/232460273-15bc444d-9d13-43ac-adbe-a34cbca485ed.png">


**3.** [This](https://github.com/gravitywiz/gravityforms-openai/compare/saif/fix/46565-feed-form-duplication#diff-ba1162f52c9cca67b2864d9b8baaab56c721ca7cfbad7fd81b335223864bf864R480-R483) enables the feed duplication when the form is duplicated. A quick screencast of this update: https://www.loom.com/share/a155d55ccbba4aa98e495b8a73588764

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Sent a packed build