### PR TITLE
Fixed issue where non-OpenAI merge tag output for multi-input field types such as checkboxes could get inadvertently cleared out.

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -1466,12 +1466,6 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 			$modifiers_str = rgar( $match, $i );
 			$modifiers     = $this->parse_modifiers( $modifiers_str );
 
-			// Ensure our field is question has a value
-			if ( ! rgar( $entry, $input_id ) ) {
-				$text = str_replace( $match[0], '', $text );
-				continue;
-			}
-
 			$feed_id = null;
 
 			foreach ( $modifiers as $modifier ) {
@@ -1481,7 +1475,14 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 				}
 			}
 
+			// Do not process if we don't have a match on openai_feed_ as a modifier as it could impact other merge tags.
 			if ( ! is_numeric( $feed_id ) ) {
+				continue;
+			}
+
+			// Ensure our field in question has a value
+			if ( ! rgar( $entry, $input_id ) ) {
+				$text = str_replace( $match[0], '', $text );
 				continue;
 			}
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2229131097/47734?folderId=3808239

## Summary

When including an OpenAI feed merge tag in a notification, it prevents checkbox merge tags from showing. This was caused because of this check we had :

```
	// Ensure our field is question has a value
	if ( ! rgar( $entry, $input_id ) ) {
		$text = str_replace( $match[0], '', $text );
		continue;
	}
```

This checks if a particular entry field is empty, then its merge tag can be replaced by empty text. This will always run for the checkbox because the values for checkboxes are stored with ids `4.1`, `4.2`, `4.3` (for a checkbox of field ID 4).

<img width="248" alt="Screenshot 2023-05-02 at 10 42 34 PM" src="https://user-images.githubusercontent.com/26293394/235736880-fe3a6348-62f8-4137-b586-7b67555703f7.png">

We can skip this check for the checkbox `GFAPI::get_field( $form, $input_id )->type !== 'checkbox'`. Rest of Gravity Forms logic will compute empty string for checkbox, if a checkbox doesn't have any value while maintaining selected checkbox values when there are.


## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Sent a packed build