### PR TITLE
Added `gpt-3.5-turbo-16k` as an available model for the Chat Completions endpoint.

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -292,13 +292,14 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 				'gpt-3.5-turbo' => array(
 					'description' => __( 'The same model used by <a href="https://chat.openai.com" target="_blank">ChatGPT</a>.', 'gravityforms-openai' ),
 				),
+				'gpt-3.5-turbo-16k' => array(
+					'description' => __( 'Same capabilities as the standard gpt-3.5-turbo model but with 4x the context length.', 'gravityforms-openai' ),
+				),
 				'gpt-4'         => array(
-					'waitlist'    => 'https://openai.com/waitlist/gpt-4-api',
-					'description' => __( 'More capable than any GPT-3.5 model, able to do more complex tasks, and optimized for chat. Will be updated with the latest model iteration.<br /><br /><a target="_blank" href="https://openai.com/waitlist/gpt-4-api">Join Waitlist</a>', 'gravityforms-openai' ),
+					'description' => __( 'More capable than any GPT-3.5 model, able to do more complex tasks, and optimized for chat. Will be updated with the latest model iteration.', 'gravityforms-openai' ),
 				),
 				'gpt-4-32k'     => array(
-					'description' => __( 'Same capabilities as the base gpt-4 mode but with 4x the context length. Will be updated with the latest model iteration.<br /><br /><a target="_blank" href="https://openai.com/waitlist/gpt-4-api">Join Waitlist</a>', 'gravityforms-openai' ),
-					'waitlist'    => 'https://openai.com/waitlist/gpt-4-api',
+					'description' => __( 'Same capabilities as the base gpt-4 mode but with 4x the context length. Will be updated with the latest model iteration.', 'gravityforms-openai' ),
 				),
 			),
 			'edits'            => array(


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2290938598/51686

## Summary

Also, removed "waitlist" from `gpt-4` and `gpt-4-32k` since these are now [generally available](https://help.openai.com/en/articles/7102672-how-can-i-access-gpt-4). Some concerns about this below.

### Concerns

So, "generally available" does have some conditions. 

- `gpt-4` is only available if you've successfully paid OpenAI money. I haven't. 😆
- `gpt-4-32k` appears to only be available to people who already have it. From OpenAI's docs:

    > We are not currently granting access to GPT-4-32K API at this time, but it will be made available at a later date.

[redacted]

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Sent a packed build