### PR TITLE
Add a filter to the OpenAI response.

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -1727,6 +1727,8 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 			return $response;
 		}
 
+		$response = apply_filters( 'gf_openai_response', $response, $body, $endpoint, $feed );
+
 		$request_cache[ $cache_key ] = $response;
 
 		if ( $use_cache ) {


### PR DESCRIPTION
The purpose of this PR is to add a filter to the OpenAI response.

1. I want to make sure it returns the appropriate content i.e. check for key words, or structure. In my current use case it is supposed to return JSON and if it doesn’t I can send it back to openai to try again.
1. In some cases responses can be longer than the maximum number of tokens and therefore the the `finish_reason` reason might not be `stop` and  in that case I send the response back with the additional message to “Continue previous response where you left off. Be aware if the previous response ended mid-sentence or in the middle of an html tag.”
1. If a dev modifies the request body to make it a streaming request, the response will need to be modified to handle this change.

I am sure other users can come up with additional use cases.

@spivurno and I have already discussed this. 