### PR TITLE
Fixed an issue where merge tag would not use already generated data and retrieve a new response instad.

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -1535,6 +1535,12 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 		$feed     = $this->get_feed( $feed_id );
 		$endpoint = rgars( $feed, 'meta/endpoint' );
 
+		// If a response was already generated, retrieve it.
+		$response_data = json_decode( gform_get_meta( $entry['id'], 'openai_response_' . $feed['id'] ), true );
+		if ( ! rgar( $response_data, 'error' ) ) {
+			return $this->get_text_from_response( $response_data );
+		}
+
 		if ( ! $endpoint || (int) rgar( $feed, 'form_id' ) !== (int) rgar( $form, 'id' ) ) {
 			return '';
 		}


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2393974832/56193/

## Summary

The OpenAI feed maps the result to a field and a merge tag, the responses shown in the field and merge tag are different. On the `get_merge_tag_replacement` method, we regenerate the response. Instead we should be looking for an already generated response, and if found we just use that.

**BEFORE:** (slightly cropped screenshots to depict the crux of the issue)
<img width="636" alt="Screenshot 2023-10-20 at 5 23 13 PM" src="https://github.com/gravitywiz/gravityforms-openai/assets/26293394/858d0370-48c0-4ad3-8c28-9189e2f16644">

**AFTER:**
<img width="661" alt="Screenshot 2023-10-20 at 5 23 49 PM" src="https://github.com/gravitywiz/gravityforms-openai/assets/26293394/e52d9011-2faf-4123-81c3-a8068a864075">


## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Sent a packed build