### PR TITLE
Added `gpt-4-1106-preview` as an available model for the Chat Completions endpoint.

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -299,17 +299,20 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 				),
 			),
 			'chat/completions' => array(
-				'gpt-3.5-turbo'     => array(
+				'gpt-3.5-turbo'      => array(
 					'description' => __( 'The same model used by <a href="https://chat.openai.com" target="_blank">ChatGPT</a>.', 'gravityforms-openai' ),
 				),
-				'gpt-3.5-turbo-16k' => array(
+				'gpt-3.5-turbo-16k'  => array(
 					'description' => __( 'Same capabilities as the standard gpt-3.5-turbo model but with 4x the context length.', 'gravityforms-openai' ),
 				),
-				'gpt-4'             => array(
+				'gpt-4'              => array(
 					'description' => __( 'More capable than any GPT-3.5 model, able to do more complex tasks, and optimized for chat. Will be updated with the latest model iteration.', 'gravityforms-openai' ),
 				),
-				'gpt-4-32k'         => array(
+				'gpt-4-32k'          => array(
 					'description' => __( 'Same capabilities as the base gpt-4 mode but with 4x the context length. Will be updated with the latest model iteration.', 'gravityforms-openai' ),
+				),
+				'gpt-4-1106-preview' => array(
+					'description' => __( 'The latest GPT-4 model with improved instruction following, JSON mode, reproducible outputs, parallel function calling, and more. Returns a maximum of 4,096 output tokens.', 'gravityforms-openai' ),
 				),
 			),
 			'edits'            => array(


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2420817825/57337?folderId=3808239

## Summary

Added support for [GPT-4 Turbo](https://platform.openai.com/docs/models/gpt-4-and-gpt-4-turbo#:~:text=TRAINING%20DATA-,gpt-4-1106-preview,-GPT-4%20Turbo).

## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [ ] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Sent a packed build