### PR TITLE
Fixed an issue where different cache key is generated for the same message content

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -1358,7 +1358,7 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 
 		$cache_key = sha1( serialize( array(
 			'url'            => $url,
-			'body'           => $body,
+			'body'           => map_deep( $body, 'sanitize_text_field' ),
 			'request_params' => $this->get_request_params( $feed ),
 		) ) );
 


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/2560473810/64343

## Summary
The issue here is the [message](https://github.com/gravitywiz/gravityforms-openai/blob/master/class-gwiz-gf-openai.php#L925) string that is used to generate the cache key. Though both values(first the value used to populate the live merge tag, and the one used to run the feed on form submission) look the same, but `strlen` shows they have different lengths.