### PR TITLE
Added dismissible deprecation notice and updated plugin title.

### DIFF
--- a/class-gwiz-gf-openai.php
+++ b/class-gwiz-gf-openai.php
@@ -47,8 +47,8 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 	protected $_path        = 'gravityforms-openai/gravityforms-openai.php';
 	protected $_full_path   = __FILE__;
 	protected $_slug        = 'gravityforms-openai';
-	protected $_title       = 'Gravity Forms OpenAI';
-	protected $_short_title = 'OpenAI (Free)';
+	protected $_title       = 'Gravity Forms OpenAI (deprecated).';
+	protected $_short_title = 'OpenAI (Deprecated)';
 
 	/**
 	 * Defines the capabilities needed for the Add-On.
@@ -253,6 +253,55 @@ class GWiz_GF_OpenAI extends GFFeedAddOn {
 		add_filter( 'gform_validation_message', array( $this, 'modify_validation_message' ), 15, 2 );
 		add_filter( 'gform_entry_is_spam', array( $this, 'moderations_endpoint_spam' ), 10, 3 );
 		add_filter( 'gform_pre_replace_merge_tags', array( $this, 'replace_merge_tags' ), 10, 7 );
+
+		add_action( 'admin_notices', array( $this, 'maybe_display_deprecation_notice' ) );
+		add_action( 'wp_ajax_gwiz_gf_openai_dismiss_deprecation_notice', array( $this, 'dismiss_deprecation_notice' ) );
+	}
+
+	/**
+	 * Displays a one-time deprecation notice in wp-admin.
+	 */
+	public function maybe_display_deprecation_notice() {
+		if ( ! current_user_can( 'activate_plugins' ) || $this->is_deprecation_notice_dismissed() ) {
+			return;
+		}
+		?>
+		<div class="notice notice-warning is-dismissible gwiz-gf-openai-deprecation-notice">
+			<p>The <strong>Gravity Forms OpenAI</strong> plugin has been deprecated and is no longer actively maintained. The plugin will continue to function as-is, but it will <strong>not receive future updates, improvements, or bug fixes.</strong></p>
+			<p>For continued development, enhanced features, and ongoing support, we recommend upgrading to <a href="https://gravitywiz.com/documentation/gravity-connect-openai/">Gravity Connect OpenAI</a>, our premium solution built specifically for long-term reliability and expansion.</p>
+		</div>
+		<script>
+			jQuery( document ).on( 'click', '.gwiz-gf-openai-deprecation-notice .notice-dismiss', function() {
+				jQuery.post( ajaxurl, {
+					action: 'gwiz_gf_openai_dismiss_deprecation_notice',
+					nonce: '<?php echo esc_js( wp_create_nonce( 'gwiz_gf_openai_dismiss_deprecation_notice' ) ); ?>'
+				} );
+			} );
+		</script>
+		<?php
+	}
+
+	/**
+	 * Persist dismissal of the deprecation notice for the current user.
+	 */
+	public function dismiss_deprecation_notice() {
+		check_ajax_referer( 'gwiz_gf_openai_dismiss_deprecation_notice', 'nonce' );
+
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			wp_send_json_error();
+		}
+
+		update_user_meta( get_current_user_id(), 'gwiz_gf_openai_deprecation_notice_dismissed', 1 );
+		wp_send_json_success();
+	}
+
+	/**
+	 * Checks whether the deprecation notice has been dismissed by the current user.
+	 *
+	 * @return bool
+	 */
+	public function is_deprecation_notice_dismissed() {
+		return (bool) get_user_meta( get_current_user_id(), 'gwiz_gf_openai_deprecation_notice_dismissed', true );
 	}
 
 	/**

--- a/gravityforms-openai.php
+++ b/gravityforms-openai.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Gravity Forms OpenAI (Free)
+ * Plugin Name: Gravity Forms OpenAI (deprecated).
  * Description: Pair the magic of OpenAI's robust models with Gravity Forms' flexibility.
  * Plugin URI: https://gravitywiz.com/gravity-forms-openai/
  * Version: 1.0-beta-1.15


### PR DESCRIPTION
## Context

⛑️ Ticket(s): https://secure.helpscout.net/conversation/3240857435/98522?viewId=3808239

## Summary

This PR marks the plugin as deprecated by updating the plugin title to `Gravity Forms OpenAI (deprecated).` and adding a dismissible admin warning notice.

<img width="985" height="370" alt="image" src="https://github.com/user-attachments/assets/acf558f7-ddf0-4ca3-9568-8a26d82f97a3" />


## Checklist

- [ ] Updated customer telling them that a fix/addition is in the works.
- [ ] Added/Improved Cypress tests or a note under _Summary_ why tests are not included in the PR.
- [x] Added a link to this PR in the Help Scout ticket(s) in the form of a note
- [ ] Added/updated hook documentation if applicable.
- [ ] Sent a [packed build](https://www.notion.so/gravitywiz/GWiz-Builder-de063e85494e4a8aace9994a3ef793f9#9de8bd246edb4d108324e5eb32b4d597) of this PR/branch for the customer to test.
